### PR TITLE
fix: resolve template freeze and mobile keyboard bugs

### DIFF
--- a/code/app/api/templates/meals/route.ts
+++ b/code/app/api/templates/meals/route.ts
@@ -30,16 +30,22 @@ export async function GET(request: NextRequest) {
       )
     }
 
-    // Get templates with filters
-    const templates = await getMealTemplates(user.id, {
+    // Get templates with filters + pagination
+    const take = parseInt(searchParams.get("take") || "50", 10)
+    const skip = parseInt(searchParams.get("skip") || "0", 10)
+
+    const { templates, total } = await getMealTemplates(user.id, {
       mealType,
       tags,
-      search
+      search,
+      take: Math.min(take, 100),
+      skip
     })
 
     return NextResponse.json({
       templates,
-      count: templates.length
+      count: templates.length,
+      total
     })
 
   } catch (error: any) {

--- a/code/app/api/templates/workouts/route.ts
+++ b/code/app/api/templates/workouts/route.ts
@@ -30,16 +30,22 @@ export async function GET(request: NextRequest) {
       )
     }
 
-    // Get templates with filters
-    const templates = await getWorkoutTemplates(user.id, {
+    // Get templates with filters + pagination
+    const take = parseInt(searchParams.get("take") || "50", 10)
+    const skip = parseInt(searchParams.get("skip") || "0", 10)
+
+    const { templates, total } = await getWorkoutTemplates(user.id, {
       difficulty,
       tags,
-      search
+      search,
+      take: Math.min(take, 100),
+      skip
     })
 
     return NextResponse.json({
       templates,
-      count: templates.length
+      count: templates.length,
+      total
     })
 
   } catch (error: any) {

--- a/code/app/dashboard/layout.tsx
+++ b/code/app/dashboard/layout.tsx
@@ -9,7 +9,7 @@ export default async function DashboardLayout({
   const user = await requireAuth()
 
   return (
-    <div className="flex h-screen bg-gray-50 dark:bg-gray-900">
+    <div className="flex h-dvh bg-gray-50 dark:bg-gray-900">
       <DashboardShell user={user}>
         {children}
       </DashboardShell>

--- a/code/app/layout.tsx
+++ b/code/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import SessionProvider from "@/components/auth/SessionProvider";
 import { ThemeProvider } from "@/components/theme/ThemeProvider";
@@ -13,6 +13,10 @@ const geistMono = Geist_Mono({
   variable: "--font-geist-mono",
   subsets: ["latin"],
 });
+
+export const viewport: Viewport = {
+  interactiveWidget: 'resizes-content',
+};
 
 export const metadata: Metadata = {
   title: "Dashboard Personal",

--- a/code/components/dashboard/DashboardShell.tsx
+++ b/code/components/dashboard/DashboardShell.tsx
@@ -1,10 +1,29 @@
 "use client"
 
-import { useState } from "react"
+import { useState, useEffect } from "react"
 import Sidebar from "./Sidebar"
 import Header from "./Header"
 import MobileDrawer from "./MobileDrawer"
 import MobileBottomNav from "./MobileBottomNav"
+
+function useKeyboardVisible() {
+  const [isKeyboardVisible, setIsKeyboardVisible] = useState(false)
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || !window.visualViewport) return
+
+    const viewport = window.visualViewport
+    const handleResize = () => {
+      const isKeyboard = viewport.height < window.innerHeight * 0.75
+      setIsKeyboardVisible(isKeyboard)
+    }
+
+    viewport.addEventListener('resize', handleResize)
+    return () => viewport.removeEventListener('resize', handleResize)
+  }, [])
+
+  return isKeyboardVisible
+}
 
 interface DashboardShellProps {
   user: {
@@ -16,6 +35,7 @@ interface DashboardShellProps {
 
 export default function DashboardShell({ user, children }: DashboardShellProps) {
   const [isDrawerOpen, setIsDrawerOpen] = useState(false)
+  const isKeyboardVisible = useKeyboardVisible()
 
   const openDrawer = () => setIsDrawerOpen(true)
   const closeDrawer = () => setIsDrawerOpen(false)
@@ -31,7 +51,7 @@ export default function DashboardShell({ user, children }: DashboardShellProps) 
       {/* Main content area */}
       <div className="flex-1 flex flex-col overflow-hidden">
         <Header user={user} onMenuClick={openDrawer} />
-        <main className="flex-1 overflow-y-auto pb-20 md:pb-0">
+        <main className={`flex-1 overflow-y-auto ${isKeyboardVisible ? 'pb-2' : 'pb-20'} md:pb-0`}>
           {children}
         </main>
       </div>

--- a/code/components/dashboard/MobileBottomNav.tsx
+++ b/code/components/dashboard/MobileBottomNav.tsx
@@ -1,9 +1,29 @@
 "use client"
 
+import { useState, useEffect } from "react"
 import Link from "next/link"
 import { usePathname } from "next/navigation"
 import { EllipsisHorizontalIcon } from "@heroicons/react/24/outline"
 import { bottomNavItems } from "@/lib/navigation"
+
+function useKeyboardVisible() {
+  const [isKeyboardVisible, setIsKeyboardVisible] = useState(false)
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || !window.visualViewport) return
+
+    const viewport = window.visualViewport
+    const handleResize = () => {
+      const isKeyboard = viewport.height < window.innerHeight * 0.75
+      setIsKeyboardVisible(isKeyboard)
+    }
+
+    viewport.addEventListener('resize', handleResize)
+    return () => viewport.removeEventListener('resize', handleResize)
+  }, [])
+
+  return isKeyboardVisible
+}
 
 interface MobileBottomNavProps {
   onMoreClick: () => void
@@ -11,6 +31,9 @@ interface MobileBottomNavProps {
 
 export default function MobileBottomNav({ onMoreClick }: MobileBottomNavProps) {
   const pathname = usePathname()
+  const isKeyboardVisible = useKeyboardVisible()
+
+  if (isKeyboardVisible) return null
 
   return (
     <nav className="fixed bottom-0 left-0 right-0 z-40 bg-white dark:bg-gray-800 border-t border-gray-200 dark:border-gray-700 md:hidden safe-area-bottom">

--- a/code/components/templates/MealTemplateManager.tsx
+++ b/code/components/templates/MealTemplateManager.tsx
@@ -59,7 +59,7 @@ interface MealTemplate {
 
 export default function MealTemplateManager() {
   const [templates, setTemplates] = useState<MealTemplate[]>([])
-  const [loading, setLoading] = useState(false)
+  const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [showDialog, setShowDialog] = useState(false)
   const [editingTemplate, setEditingTemplate] = useState<MealTemplate | null>(null)
@@ -173,7 +173,12 @@ export default function MealTemplateManager() {
         throw new Error(errorData.error || 'Failed to save template')
       }
 
-      await fetchTemplates()
+      const result = await response.json()
+      if (editingTemplate) {
+        setTemplates(prev => prev.map(t => t.id === editingTemplate.id ? result.template : t))
+      } else {
+        setTemplates(prev => [result.template, ...prev])
+      }
       setShowDialog(false)
     } catch (err: any) {
       setError(err.message)
@@ -193,7 +198,7 @@ export default function MealTemplateManager() {
 
       if (!response.ok) throw new Error('Failed to delete template')
 
-      await fetchTemplates()
+      setTemplates(prev => prev.filter(t => t.id !== id))
     } catch (err: any) {
       setError(err.message)
     } finally {

--- a/code/components/templates/MealTemplateSelector.tsx
+++ b/code/components/templates/MealTemplateSelector.tsx
@@ -96,30 +96,26 @@ export default function MealTemplateSelector({
     }
   }
 
-  const loadTemplate = async (templateId: string) => {
-    setLoading(true)
-    setError(null)
-
-    try {
-      const response = await fetch(`/api/templates/meals/${templateId}/load`)
-
-      if (!response.ok) {
-        throw new Error('Failed to load template')
-      }
-
-      const result = await response.json()
-      onTemplateLoad(result.data)
-      setIsOpen(false)
-    } catch (err: any) {
-      setError(err.message || 'Error loading template')
-    } finally {
-      setLoading(false)
-    }
-  }
-
   const handleSelect = (template: MealTemplate) => {
     setSelectedTemplate(template)
-    loadTemplate(template.id)
+    onTemplateLoad({
+      name: template.name,
+      mealType: template.mealType,
+      totalCalories: template.totalCalories,
+      totalProtein: template.totalProtein,
+      totalCarbs: template.totalCarbs,
+      totalFats: template.totalFats,
+      foodItems: template.foodItems.map(item => ({
+        name: item.name,
+        quantity: item.quantity,
+        unit: item.unit,
+        calories: item.calories,
+        protein: item.protein,
+        carbs: item.carbs,
+        fats: item.fats
+      }))
+    })
+    setIsOpen(false)
   }
 
   const getMealTypeBadge = (type: string | null) => {

--- a/code/components/templates/WorkoutTemplateManager.tsx
+++ b/code/components/templates/WorkoutTemplateManager.tsx
@@ -56,7 +56,7 @@ interface WorkoutTemplate {
 
 export default function WorkoutTemplateManager() {
   const [templates, setTemplates] = useState<WorkoutTemplate[]>([])
-  const [loading, setLoading] = useState(false)
+  const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [showDialog, setShowDialog] = useState(false)
   const [editingTemplate, setEditingTemplate] = useState<WorkoutTemplate | null>(null)
@@ -170,7 +170,12 @@ export default function WorkoutTemplateManager() {
         throw new Error(errorData.error || 'Failed to save template')
       }
 
-      await fetchTemplates()
+      const result = await response.json()
+      if (editingTemplate) {
+        setTemplates(prev => prev.map(t => t.id === editingTemplate.id ? result.template : t))
+      } else {
+        setTemplates(prev => [result.template, ...prev])
+      }
       setShowDialog(false)
     } catch (err: any) {
       setError(err.message)
@@ -190,7 +195,7 @@ export default function WorkoutTemplateManager() {
 
       if (!response.ok) throw new Error('Failed to delete template')
 
-      await fetchTemplates()
+      setTemplates(prev => prev.filter(t => t.id !== id))
     } catch (err: any) {
       setError(err.message)
     } finally {

--- a/code/components/templates/WorkoutTemplateSelector.tsx
+++ b/code/components/templates/WorkoutTemplateSelector.tsx
@@ -87,30 +87,21 @@ export default function WorkoutTemplateSelector({
     }
   }
 
-  const loadTemplate = async (templateId: string) => {
-    setLoading(true)
-    setError(null)
-
-    try {
-      const response = await fetch(`/api/templates/workouts/${templateId}/load`)
-
-      if (!response.ok) {
-        throw new Error('Failed to load template')
-      }
-
-      const result = await response.json()
-      onTemplateLoad(result.data)
-      setIsOpen(false)
-    } catch (err: any) {
-      setError(err.message || 'Error loading template')
-    } finally {
-      setLoading(false)
-    }
-  }
-
   const handleSelect = (template: WorkoutTemplate) => {
     setSelectedTemplate(template)
-    loadTemplate(template.id)
+    onTemplateLoad({
+      name: template.name,
+      exercises: template.exercises.map(ex => ({
+        exerciseTypeId: ex.exerciseTypeId,
+        muscleGroupId: ex.muscleGroupId,
+        equipmentId: ex.equipmentId,
+        sets: ex.sets,
+        reps: ex.reps,
+        weight: ex.weight,
+        notes: ex.notes
+      }))
+    })
+    setIsOpen(false)
   }
 
   const getDifficultyBadge = (diff: string | null) => {

--- a/docs/2026-02-21-fix-templates-freeze-mobile-keyboard.md
+++ b/docs/2026-02-21-fix-templates-freeze-mobile-keyboard.md
@@ -1,0 +1,87 @@
+# Fix: Templates se congelan + Espacio negro teclado movil
+
+**Fecha:** 2026-02-21
+**Estado:** Resuelto
+**Branch:** fix/templates-freeze-mobile-keyboard
+
+---
+
+## Bug 1: Templates se congelan y producen error al cargar
+
+### Causa raiz
+
+1. **Sin paginacion:** `getWorkoutTemplates()` y `getMealTemplates()` traian TODOS los registros sin limite (`take`), causando queries pesadas a medida que crecen los datos.
+2. **Double-fetch redundante:** Los selectores (`WorkoutTemplateSelector`, `MealTemplateSelector`) ya tenian todos los datos del template en memoria al hacer el fetch inicial, pero al seleccionar uno, hacian un segundo `GET /[id]/load` que re-ejecutaba la query completa con todos los `include`.
+3. **Re-fetch completo despues de cada operacion:** Despues de guardar o eliminar un template, se llamaba `fetchTemplates()` completo en vez de actualizar el state local.
+
+### Solucion aplicada
+
+#### 1. Paginacion en queries (`take: 50` por defecto)
+- **`code/lib/templates/workout-queries.ts`** — `getWorkoutTemplates()` ahora acepta `take` y `skip`, retorna `{ templates, total }`.
+- **`code/lib/templates/meal-queries.ts`** — `getMealTemplates()` igual.
+- **`code/app/api/templates/workouts/route.ts`** — Parsea `take`/`skip` de query params, cap en 100.
+- **`code/app/api/templates/meals/route.ts`** — Igual.
+
+#### 2. Eliminacion del double-fetch en selectores
+- **`code/components/templates/WorkoutTemplateSelector.tsx`** — `handleSelect()` ahora transforma los datos del template en memoria directamente, sin llamar a `/load`.
+- **`code/components/templates/MealTemplateSelector.tsx`** — Igual.
+
+#### 3. Actualizacion local del state (evita re-fetch)
+- **`code/components/templates/WorkoutTemplateManager.tsx`** — Despues de save, actualiza el array local. Despues de delete, filtra el array local. Loading state inicial en `true`.
+- **`code/components/templates/MealTemplateManager.tsx`** — Igual.
+
+### Archivos modificados
+
+| Archivo | Cambio |
+|---------|--------|
+| `code/lib/templates/workout-queries.ts` | Paginacion (take/skip), retorna { templates, total } |
+| `code/lib/templates/meal-queries.ts` | Paginacion (take/skip), retorna { templates, total } |
+| `code/app/api/templates/workouts/route.ts` | Parsea take/skip, pasa a query |
+| `code/app/api/templates/meals/route.ts` | Parsea take/skip, pasa a query |
+| `code/components/templates/WorkoutTemplateSelector.tsx` | Elimina double-fetch, usa datos locales |
+| `code/components/templates/MealTemplateSelector.tsx` | Elimina double-fetch, usa datos locales |
+| `code/components/templates/WorkoutTemplateManager.tsx` | State update local post-save/delete |
+| `code/components/templates/MealTemplateManager.tsx` | State update local post-save/delete |
+
+---
+
+## Bug 2: Espacio negro al abrir teclado en movil
+
+### Causa raiz
+
+En moviles, `100vh` (`h-screen`) incluye el area detras de la barra del navegador y NO se actualiza cuando el teclado aparece. Esto causa:
+
+1. El layout mantiene su altura completa mientras el viewport visible se reduce
+2. `MobileBottomNav` (fixed bottom-0) queda "detras" del teclado
+3. Se genera un espacio vacio (negro) entre el contenido y el bottom nav
+
+### Solucion aplicada
+
+#### 1. `h-screen` → `h-dvh`
+- **`code/app/dashboard/layout.tsx`** — `h-dvh` (dynamic viewport height) se ajusta automaticamente cuando el teclado abre/cierra.
+
+#### 2. Viewport metadata con `interactiveWidget`
+- **`code/app/layout.tsx`** — Agregado `export const viewport: Viewport = { interactiveWidget: 'resizes-content' }`. Esto indica al navegador que redimensione el contenido cuando el teclado aparece.
+
+#### 3. Ocultar MobileBottomNav con teclado abierto
+- **`code/components/dashboard/MobileBottomNav.tsx`** — Hook `useKeyboardVisible()` detecta el teclado usando `window.visualViewport`. Si viewport height < 75% de innerHeight, el nav se oculta completamente.
+
+#### 4. Padding bottom dinamico
+- **`code/components/dashboard/DashboardShell.tsx`** — Mismo hook `useKeyboardVisible()`. Cuando teclado abierto: `pb-2`, cerrado: `pb-20`.
+
+### Archivos modificados
+
+| Archivo | Cambio |
+|---------|--------|
+| `code/app/dashboard/layout.tsx` | `h-screen` → `h-dvh` |
+| `code/app/layout.tsx` | `viewport` export con `interactiveWidget: 'resizes-content'` |
+| `code/components/dashboard/MobileBottomNav.tsx` | Hook deteccion teclado, oculta nav |
+| `code/components/dashboard/DashboardShell.tsx` | Hook deteccion teclado, padding dinamico |
+
+---
+
+## Verificacion
+
+- `npx tsc --noEmit` — Sin errores
+- `npm run lint` — Sin errores nuevos
+- `npm run build` — Build exitoso


### PR DESCRIPTION
## Summary
- **Bug 1 - Templates freeze:** Added pagination (take: 50, max 100) to template queries, eliminated redundant double-fetch in selectors, and switched to local state updates after save/delete operations
- **Bug 2 - Mobile keyboard black space:** Replaced `h-screen` with `h-dvh`, added viewport `interactiveWidget: resizes-content`, hide MobileBottomNav when keyboard is open, dynamic padding in DashboardShell

## Test plan
- [ ] Load workout templates page - verify no freeze, templates load correctly
- [ ] Load meal templates page - verify no freeze, templates load correctly
- [ ] Select a template from selector dropdown - verify data loads without second API call
- [ ] Create/edit/delete a template - verify list updates without full page reload
- [ ] Open keyboard on mobile device - verify no black space appears
- [ ] Verify MobileBottomNav hides when keyboard opens
- [ ] Verify padding adjusts correctly when keyboard opens/closes

🤖 Generated with [Claude Code](https://claude.com/claude-code)